### PR TITLE
bug fixed

### DIFF
--- a/WZRippleButton/WZFlashButton.h
+++ b/WZRippleButton/WZFlashButton.h
@@ -17,6 +17,7 @@ typedef NS_ENUM(NSUInteger, WZFlashButtonType) {
 
 @interface WZFlashButton : UIView
 
+@property (nonatomic, strong) UILabel *textLabel;
 @property (nonatomic, assign) WZFlashButtonType buttonType;
 @property (nonatomic, copy) WZFlashButtonDidClickBlock clickBlock;
 

--- a/WZRippleButton/WZFlashButton.m
+++ b/WZRippleButton/WZFlashButton.m
@@ -115,9 +115,7 @@ const CGFloat WZFlashInnerCircleInitialRaius = 20;
     [circleShape addAnimation:groupAnimation forKey:nil];
     [circleShape setDelegate:self];
     
-    if (self.clickBlock) {
-        self.clickBlock();
-    }
+    
 }
 
 - (CAShapeLayer *)createCircleShapeWithPosition:(CGPoint)position pathRect:(CGRect)rect radius:(CGFloat)radius
@@ -170,6 +168,9 @@ const CGFloat WZFlashInnerCircleInitialRaius = 20;
     CALayer *layer = [anim valueForKey:@"circleShaperLayer"];
     if (layer) {
         [layer removeFromSuperlayer];
+        if (self.clickBlock) {
+            self.clickBlock();
+        }
     }
 }
 

--- a/WZRippleButton/WZFlashButton.m
+++ b/WZRippleButton/WZFlashButton.m
@@ -11,7 +11,6 @@
 const CGFloat WZFlashInnerCircleInitialRaius = 20;
 
 @interface WZFlashButton()
-@property (nonatomic, strong) UILabel *textLabel;
 @end
 
 @implementation WZFlashButton


### PR DESCRIPTION
1.sometimes we need to control the textLabel, like UILabel breakmode
and line number
2.bug description:
when i perform some UI action in the clickblock,like,[weakSelf
performSegueWithIdentifier:self.phaseSegue sender: weakSelf];the
application will crash for BAD_ACESS error. The block shoul be excited
after animation with the layer removed.
